### PR TITLE
Add .all to public interface

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,2 +1,4 @@
 Style/Documentation:
   Enabled: false
+Metrics/BlockLength:
+  Enabled: false

--- a/README.md
+++ b/README.md
@@ -42,6 +42,14 @@ puts reason_code.probable_status # declined
 
 SepaReasonCodes does not have any dependency or magic. Just check `lib/reason_codes.yml` to see the list of all reason codes.
 
+You can also retrieve all Reason Codes by doing:
+
+```ruby
+SepaReasonCodes.all
+```
+
+which will return a collection of `ReasonCode` structs.
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/lib/sepa_reason_codes.rb
+++ b/lib/sepa_reason_codes.rb
@@ -36,6 +36,18 @@ module SepaReasonCodes
 
     return unless reason_code
 
+    reason_code_struct(reason_code)
+  end
+
+  # @returns collection [reason_code]
+
+  def self.all
+    ParsedReasonCodes.values.map do |reason_code|
+      reason_code_struct(reason_code)
+    end
+  end
+
+  def self.reason_code_struct(reason_code)
     ReasonCodeStruct.new(
       reason_code.fetch('code'),
       reason_code.fetch('iso_name'),
@@ -43,4 +55,7 @@ module SepaReasonCodes
       reason_code.fetch('probable_status')
     )
   end
+
+  private_constant :ParsedReasonCodes
+  private_class_method :reason_code_struct
 end

--- a/spec/sepa_reason_codes_spec.rb
+++ b/spec/sepa_reason_codes_spec.rb
@@ -5,23 +5,31 @@ RSpec.describe SepaReasonCodes do
     expect(SepaReasonCodes::VERSION).not_to be nil
   end
 
-  context 'when reason code exists' do
-    it 'returns reason code struct' do
-      reason_code = 'AC01'
+  describe '.find' do
+    context 'when reason code exists' do
+      it 'returns reason code struct' do
+        reason_code = 'AC01'
 
-      result = described_class.find(reason_code)
-      expect(result.code).to eq('AC01')
-      expect(result.iso_name).to eq('Incorrect Account Number')
-      expect(result.description).to eq(
-        'Account number is invalid or missing. Format of the account number specified is not correct'
-      )
-      expect(result.probable_status).to eq('declined')
+        result = described_class.find(reason_code)
+        expect(result.code).to eq('AC01')
+        expect(result.iso_name).to eq('Incorrect Account Number')
+        expect(result.description).to eq(
+          'Account number is invalid or missing. Format of the account number specified is not correct'
+        )
+        expect(result.probable_status).to eq('declined')
+      end
+    end
+
+    context "when reason code doesn't exist" do
+      it 'returns nil' do
+        expect(described_class.find('doesnt-exist')).to be_nil
+      end
     end
   end
 
-  context "when reason code doesn't exist" do
-    it 'returns nil' do
-      expect(described_class.find('doesnt-exist')).to be_nil
+  describe '.all' do
+    it 'returns all reason codes' do
+      expect(described_class.all.size).to eq(217)
     end
   end
 end


### PR DESCRIPTION
- Adds .all to `SepaReasonCodes` module to retrieve a collection of ReasonCode Structs